### PR TITLE
Workspace buffer allocation

### DIFF
--- a/PlaitsEngines1.2/PlaitsEngines1.2.ino
+++ b/PlaitsEngines1.2/PlaitsEngines1.2.ino
@@ -37,7 +37,7 @@ constexpr int AUDIO_BLOCK = plaits::kBlockSize;
 // ==================== MEMORY BUFFERS ====================
 static uint8_t shared_plaits_workspace[WORKSPACE_SIZE] __attribute__((aligned(4)));
 static uint16_t clouds_buffer[65536];
-static uint16_t oliverb_buffer[131072];
+static uint16_t oliverb_buffer[65536];
 
 int16_t left[AUDIO_BLOCK];
 int16_t right[AUDIO_BLOCK];

--- a/PlaitsEnginesScarp1.2/PlaitsEnginesScarp1.2.ino
+++ b/PlaitsEnginesScarp1.2/PlaitsEnginesScarp1.2.ino
@@ -61,7 +61,7 @@ constexpr int AUDIO_BLOCK = plaits::kBlockSize;
 // ==================== MEMORY BUFFERS ====================
 static uint8_t shared_plaits_workspace[WORKSPACE_SIZE] __attribute__((aligned(4)));
 static uint16_t clouds_buffer[65536];
-static uint16_t oliverb_buffer[131072];
+static uint16_t oliverb_buffer[65536];
 
 int16_t left[AUDIO_BLOCK];
 int16_t right[AUDIO_BLOCK];


### PR DESCRIPTION
ESP-32 example changed to static workspace allocation.
Oliverb workspace amount in the examples safely changed to 65536 which is enough. 